### PR TITLE
Add ability to load data from URL query parameters

### DIFF
--- a/assets/js/controller.js
+++ b/assets/js/controller.js
@@ -67,18 +67,13 @@ export default class Controller {
 
   async loadFromQueryParameters() {
     const queryParameters = new URLSearchParams(window.location.search)
-    const nodesUrl = queryParameters.get('n_u');
-    const edgesUrl = queryParameters.get('e_u');
-    const configUrl = queryParameters.get('c_u');
-    if (isValidHttpsUrl(nodesUrl) && isValidHttpsUrl(edgesUrl) && isValidHttpsUrl(configUrl)) {
+    const dataUrl = queryParameters.get('d_u');
+    if (isValidHttpsUrl(dataUrl)) {
       try {
-        const [nodes, edges, config] = await Promise.all([
-          fetch(nodesUrl).then(r => r.json()),
-          fetch(edgesUrl).then(r => r.json()),
-          fetch(configUrl).then(r => r.json())
-        ]);
+        const response = await fetch(dataUrl).then(r => r.json());
         document.getElementById('spinnerDiv').style.display = 'flex';
-        return { nodes, links: edges, config }
+        const { nodes, edges: links, config } = response;
+        return { nodes, links, config }
       } catch(e) {
         console.error(`error fetching data file`);
         console.error(e);

--- a/assets/js/controller.js
+++ b/assets/js/controller.js
@@ -9,6 +9,7 @@ import * as turf from '@turf/turf';
 import { LayerCardsContainer } from '../react/layers/layers_container';
 import crossfilter from 'crossfilter2';
 import { data } from 'jquery';
+import { isValidHttpsUrl } from './util.js';
 
 export default class Controller {
   constructor(model, view) {
@@ -25,19 +26,70 @@ export default class Controller {
                 console.log("Aucune donnée trouvée dans IndexedDB.");
             }
         }); */
+    this.initialize();
+  }
+  
+  async initialize() {
+    this.tryPreloadData();
+    // let initialSetup run otherwise empty projection dropdown
+    this.initialSetup();
+  }
 
-    window.addEventListener('message', (event) => {
-      const data = event.data;
-      if (data.type === 'arabesqueData') {
-        // Afficher le spinner d'attente
-        document.getElementById('spinnerDiv').style.display = 'flex';
-        // Ajouter un léger délai pour éviter que l'application ne se déclenche avant l'import des data
-        setTimeout(() => {
-          this.handleExternalData(data.content);
-        }, 500);
-      }
+  async tryPreloadData() {
+    let data = await this.loadFromQueryParameters();
+    // the other tab waits for 2000ms so we give it 3000ms to send a message
+    data = data || await this.loadFromPostMessage(3000);
+    if (data) {
+      // show a spinner for 500ms then load the data
+      document.getElementById('spinnerDiv').style.display = 'flex';
+      setTimeout(() => {
+        this.handleExternalData(data);
+      }, 500);
+    }
+  }
+
+  async loadFromPostMessage(timeout) {
+    return new Promise((resolve) => {
+      const messageHandler = (event) => {
+        const data = event.data;
+        if (data.type === 'arabesqueData') {
+          window.removeEventListener('message', messageHandler);
+          resolve(data.content);
+        }
+      };
+      window.addEventListener('message', messageHandler);
+      setTimeout(() => { // remove listener if no data after timeout
+        window.removeEventListener('message', messageHandler);
+        resolve(null);
+      }, timeout);
     });
+  }
 
+  async loadFromQueryParameters() {
+    const queryParameters = new URLSearchParams(window.location.search)
+    const nodesUrl = queryParameters.get('n_u');
+    const edgesUrl = queryParameters.get('e_u');
+    const configUrl = queryParameters.get('c_u');
+    if (isValidHttpsUrl(nodesUrl) && isValidHttpsUrl(edgesUrl) && isValidHttpsUrl(configUrl)) {
+      try {
+        const [nodes, edges, config] = await Promise.all([
+          fetch(nodesUrl).then(r => r.json()),
+          fetch(edgesUrl).then(r => r.json()),
+          fetch(configUrl).then(r => r.json())
+        ]);
+        document.getElementById('spinnerDiv').style.display = 'flex';
+        return { nodes, links: edges, config }
+      } catch(e) {
+        console.error(`error fetching data file`);
+        console.error(e);
+        throw e
+      }
+    } else {
+      console.log('no query param files')
+    }
+  }
+
+  initialSetup() {
     this.render_layers_cards();
 
     document
@@ -1152,6 +1204,7 @@ export default class Controller {
   }
 
   handleExternalData(data) {
+    document.getElementById('spinnerDiv').style.display = 'flex';
     // Vérifier que les données sont valides
     if (!data.nodes || !data.links) {
       console.error('Invalid data format: nodes and links are required.');

--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -1,0 +1,9 @@
+export function isValidHttpsUrl(string) {
+  let url;
+  try {
+    url = new URL(string);
+  } catch (_) {
+    return false;  
+  }
+  return url.protocol === "https:";
+}

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta http-equiv="Content-Security-Policy"
-        content="style-src 'self' 'unsafe-inline'; default-src 'self'; img-src 'self' data: http:; script-src 'self' 'unsafe-eval';">
+        content="style-src 'self' 'unsafe-inline'; default-src 'self'; connect-src 'self' https://assets.cortext.net; img-src 'self' data: http:; script-src 'self' 'unsafe-eval';">
     <meta charset="UTF-8">
     <title>Arabesque</title>
 </head>


### PR DESCRIPTION
This PR adds functionality to load data directly from external HTTPS URLs via query parameters, desirable for the upcoming cortext integration. A complete dataset can now be specified without requiring manual import.

## Changes
- Added URL parameter support to load data via `d_u` (data) parameter for complete datasets
- Created a new utility function `isValidHttpsUrl()` to validate HTTPS URLs
- Added proper initialization sequence with `initialize()` and `tryPreloadData()` methods
- Modified Content Security Policy to allow connections to `https://assets.cortext.net` 
- Refactored message event handling into a promise-based function with timeout

## Example Usage
Users can now load a complete dataset with a URL like:

```
https://arabesque.url/?d_u=https://allowed.source.com/dataset.json
```

The expected JSON format should contain:

```json
{
  "nodes": [...],
  "edges": [...],
  "config": {...}
}
```

Following the schemas specified in the [example page](https://tonhauck.github.io/dev-arabesque/test-instance-arabesque.html).

## Security Considerations

- Only HTTPS URLs are accepted
- CSP has been updated to explicitly allow connections to authorized domains

Of course, any suggestions/further improvements are welcome